### PR TITLE
add support for loggers with diffrente admin panels

### DIFF
--- a/config/filament-activity-log.php
+++ b/config/filament-activity-log.php
@@ -4,6 +4,16 @@ use Noxo\FilamentActivityLog\ResourceLogger\Types\BooleanEnum;
 
 return [
     'loggers' => [
+        'panels' => [
+        /**
+         * Add different admin panels with its directory and namespace. E.g:
+         *    'panel-1' => [
+         *       'directory' => app_path('Filament/Panel1/Loggers'),
+         *       'namespace' => 'App\\Filament\\Panel1\\Loggers',
+         *    ]
+         */
+        ],
+        // Default panel
         'directory' => app_path('Filament/Loggers'),
         'namespace' => 'App\\Filament\\Loggers',
     ],

--- a/src/Loggers/Loggers.php
+++ b/src/Loggers/Loggers.php
@@ -26,13 +26,27 @@ class Loggers
     public static function discover(): void
     {
         $config = config('filament-activity-log.loggers');
+
+        if (array_key_exists('panels', $config) && count($config['panels']) > 0) {
+            foreach ($config['panels'] as $panelLoggers) {
+                static::setLogger($panelLoggers['directory'], $panelLoggers['namespace']);
+            }
+        }
+
+        // Default panel
         $directory = $config['directory'];
         $namespace = $config['namespace'];
-        $baseClass = Logger::class;
 
+        static::setLogger($directory, $namespace);
+    }
+
+    private static function setLogger(string $directory, string $namespace): void
+    {
         if (blank($directory) || blank($namespace)) {
             return;
         }
+
+        $baseClass = Logger::class;
 
         $filesystem = app(Filesystem::class);
 


### PR DESCRIPTION
Some loggers may be needed only for specific filament admin panels rather than the [default filament admin panel](https://filamentphp.com/docs/3.x/panels/configuration#introducing-panels).

When loggers are created using `php artisan make:filament-logger` and having more than one panel, it asks where to create it, thus when trying to access the logger, this is not resolved because the directory and namespace are setup in config file only for the default admin panl.