### PR TITLE
Fix nullable causer error

### DIFF
--- a/src/Services/Helper.php
+++ b/src/Services/Helper.php
@@ -23,8 +23,12 @@ final class Helper
     /**
      * @return class-string<Logger>
      */
-    public static function resolveLogger(string | Model $record, bool $force = false): ?string
+    public static function resolveLogger(null | string | Model $record, bool $force = false): ?string
     {
+        if (!$record) {
+            return null;
+        }
+
         $name = is_string($record) ? $record : get_class($record);
 
         return Loggers::getLoggerByModel($name, $force);


### PR DESCRIPTION
The `spatie/laravel-activitylog` package allows nulable causers, but if you have one, the package fails with exception:

```
Noxo\FilamentActivityLog\Services\Helper::resolveLogger(): Argument #1 ($record) must be of type Illuminate\Database\Eloquent\Model|string, null given, called in /var/www/html/vendor/noxoua/filament-activity-log/src/Pages/Concerns/HasLogger.php on line 13 
```

This MR adds a null check to the `resolveLogger` function.