### PR TITLE
Allow using the activity_model value in spaties base package config file

### DIFF
--- a/src/Pages/ListActivities.php
+++ b/src/Pages/ListActivities.php
@@ -60,8 +60,10 @@ abstract class ListActivities extends Page implements HasForms
 
     public function getActivities()
     {
+        $activityModel = config('activitylog.activity_model') ?? Activity::class;
+
         return $this->paginateTableQuery(
-            $this->applyFilters(Activity::latest())
+            $this->applyFilters($activityModel::latest())
         );
     }
 


### PR DESCRIPTION
There are cases when one would want to use a custom model as the Activity model.

Practical cases

- i've disabled lazy loading and Activity is attempting to lazy load `causer` and `subject`
- i need to set up a separate database connection for the Activity model as it will not be stored in the application's main database

The change is very similar to how Spatie themselves are using it in the base ActivityLog package.
Or rather: check if there's a configured model, otherwise use the default one.